### PR TITLE
Meta query params so team can be sorted by meta

### DIFF
--- a/classes/class-woothemes-our-team.php
+++ b/classes/class-woothemes-our-team.php
@@ -580,12 +580,10 @@ class Woothemes_Our_Team {
 		// If a meta query is specified
 		if ( is_string( $args['meta_key'] ) ) {
 			$query_args['meta_key'] = esc_html( $args['meta_key'] );
-			echo 'key';
 		}
 
 		if ( is_string( $args['meta_value'] ) ) {
 			$query_args['meta_value'] = esc_html( $args['meta_value'] );
-			echo 'value';
 		}
 
 		// Setup the taxonomy query.


### PR DESCRIPTION
I needed to be able to sort the team widget by the '_byline' meta value. Currently there was no way to do this. By giving the query a `query_id` I can filter `pre_get_posts` and only target the our team queries... or by adding `meta_key` and `meta_value` I can do it that way too. 
