### PR TITLE
Better URLs for Our Team Taxonomy

### DIFF
--- a/classes/class-woothemes-our-team-taxonomy.php
+++ b/classes/class-woothemes-our-team-taxonomy.php
@@ -90,7 +90,7 @@ class Woothemes_Our_Team_Taxonomy {
 			'query_var' 			=> true,
 			'show_in_nav_menus' 	=> false,
 			'show_tagcloud' 		=> false,
-			'rewrite'               => array( 'slug' => 'team-members', 'with_front' 	=> false )
+			'rewrite'               => array( 'slug' => 'team-members', 'with_front' => false )
 			);
 	} // End _get_default_args()
 


### PR DESCRIPTION
I updated the defaults to the our-team category taxonomy. Defaults to /team-members/category-name. I also set with_front to false so the permalinks settings such as  /blog/%postname%/  wont add /blog in front. 
