### PR TITLE
Minor js bug fix - was causing Media Browser button to stop working. 

### DIFF
--- a/classes/class-woothemes-our-team.php
+++ b/classes/class-woothemes-our-team.php
@@ -768,7 +768,7 @@ class Woothemes_Our_Team {
 					});
 
 					// Unser #user_id if #user_search is empty on page load
-					if ( jQuery( '#user_search' ).val().length == 0 ) {
+					if ( jQuery( '#user_search' ).val() && jQuery( '#user_search' ).val().length == 0 ) {
 				        jQuery( "#user_id" ).val( 0 );
 				    }
 				});


### PR DESCRIPTION
Fixes Uncaught TypeError: Cannot read property 'length' of undefined javascript error that can cause the Media Browser button (among other js-based things) to stop working.

This particular issue may be specific to my installation but the fix shouldn't hurt anyone else.

Tested on new 1.4.0 version and working. 

There's only the master branch on here now so I guess that's where this should be submitted to?

This fix is also mentioned on wordpress support forum: http://wordpress.org/support/topic/add-media-button-not-working-includes-fix
